### PR TITLE
Set correct version python

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.8


### PR DESCRIPTION
Requested runtime (python-3.5.2) is not available for this stack (heroku-18).
Read more: https://devcenter.heroku.com/articles/python-support