### PR TITLE
Upgrade flower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ backports.ssl-match-hostname==3.5.0.1
 billiard==3.5.0.3
 celery==4.1.0
 certifi==2016.9.26
-flower==0.9.2
+flower==0.9.4
 futures==3.1.1
 kombu==4.1.0
 pytz==2018.4


### PR DESCRIPTION
Upgrade flower to latest ([0.9.4](https://pypi.org/project/flower/#history)) to bring several fixes:
- Fix the ENV variable `FLOWER_AUTH2_REDIRECT_URI` => `FLOWER_OAUTH2_REDIRECT_URI`
 https://github.com/mher/flower/commit/8ac20c5ec66a292c654c36966b395e0e6c1f281e
- Fix for google oauth login https://github.com/mher/flower/commit/53ff779e887be1d4f766cecb2cdcdcd158eebe86
- Fix to work with tornado 5+ https://github.com/mher/flower/pull/842
and many more
https://github.com/mher/flower/compare/v0.9.2...v0.9.4